### PR TITLE
ci: add harden-runner to GitHub Actions workflows

### DIFF
--- a/.github/workflows/deploy_websocket_server.yml
+++ b/.github/workflows/deploy_websocket_server.yml
@@ -22,6 +22,10 @@ jobs:
       sha_short: ${{ steps.vars.outputs.sha_short }}
       sha: ${{ github.sha }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Set variables
@@ -33,6 +37,10 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@v4
       
@@ -63,6 +71,10 @@ jobs:
       IMAGE_NAME: reearth/reearth-flow-websocket
       IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-websocket
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: Checkout Repository
         uses: actions/checkout@v4
 
@@ -146,6 +158,10 @@ jobs:
       GCP_REGION: us-central1
       CLOUD_RUN_SERVICE: reearth-flow-websocket
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
## Summary

- Add step-security/harden-runner v2.16.1 as the first step in all GitHub Actions workflow jobs
- Configured with egress-policy: audit to monitor outbound traffic
- Improves supply chain security for CI/CD pipelines

## References

- [StepSecurity Harden Runner](https://github.com/step-security/harden-runner)