### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth-flow-websocket
+  namespace: reearth
+  description: fork y-redis for reearth-flow
+  annotations:
+    github.com/project-slug: reearth/reearth-flow-websocket
+  links:
+  - url: https://github.com/reearth/reearth-flow-websocket
+    title: GitHub
+    icon: github
+  tags:
+  - javascript
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/cto-office


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth-flow-websocket` (namespace `reearth`)
- **Owner:** `reearth/cto-office`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.